### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
     "lodash": "^4.17.21",
     "ndarray": "^1.0.19",
     "ndarray-ops": "^1.2.2",
-    "next": "^11.1.2",
+    "next": "^13.1.2",
     "onnxruntime-web": "^1.9.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "node-polyfill-webpack-plugin": "^1.1.4",
     "copy-webpack-plugin": "^9.0.1",
     "@types/lodash": "^4.14.176",
-    "@types/react": "17.0.19",
+    "@types/react": "^18.0.26",
     "eslint": "7.32.0",
-    "eslint-config-next": "11.1.0",
+    "eslint-config-next": "^13.1.2",
     "typescript": "4.4.2"
   }
 }


### PR DESCRIPTION
Updated the following dependencies to the latest versions: `next`, `react`, `eslint-config-next` to make the application work with `node>=18.13.0` out of the box.